### PR TITLE
add Alpine Linux support and update installation scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,14 +34,24 @@ warn() {
 # root
 [[ $EUID != 0 ]] && err "当前非 ${yellow}ROOT用户.${none}"
 
-# yum or apt-get, ubuntu/debian/centos
-cmd=$(type -P apt-get || type -P yum)
-[[ ! $cmd ]] && err "此脚本仅支持 ${yellow}(Ubuntu or Debian or CentOS)${none}."
+# yum or apt-get or apk, ubuntu/debian/centos/alpine
+cmd=$(type -P apt-get || type -P yum || type -P apk)
+[[ ! $cmd ]] && err "此脚本仅支持 ${yellow}(Ubuntu or Debian or CentOS or Alpine)${none}."
 
-# systemd
-[[ ! $(type -P systemctl) ]] && {
-    err "此系统缺少 ${yellow}(systemctl)${none}, 请尝试执行:${yellow} ${cmd} update -y;${cmd} install systemd -y ${none}来修复此错误."
-}
+# alpine linux
+is_alpine=
+[[ $cmd =~ apk ]] && is_alpine=1
+
+# systemd or openrc
+if [[ $is_alpine ]]; then
+    [[ ! $(type -P rc-service) ]] && {
+        err "此系统缺少 ${yellow}(rc-service)${none}, 请尝试执行:${yellow} ${cmd} add openrc ${none}来修复此错误."
+    }
+else
+    [[ ! $(type -P systemctl) ]] && {
+        err "此系统缺少 ${yellow}(systemctl)${none}, 请尝试执行:${yellow} ${cmd} update -y;${cmd} install systemd -y ${none}来修复此错误."
+    }
+fi
 
 # wget installed or none
 is_wget=$(type -P wget)
@@ -143,11 +153,20 @@ install_pkg() {
     if [[ $cmd_not_found ]]; then
         pkg=$(echo $cmd_not_found | sed 's/,/ /g')
         msg warn "安装依赖包 >${pkg}"
-        $cmd install -y $pkg &>/dev/null
+        if [[ $is_alpine ]]; then
+            $cmd add $pkg &>/dev/null
+        else
+            $cmd install -y $pkg &>/dev/null
+        fi
         if [[ $? != 0 ]]; then
             [[ $cmd =~ yum ]] && yum install epel-release -y &>/dev/null
-            $cmd update -y &>/dev/null
-            $cmd install -y $pkg &>/dev/null
+            if [[ $is_alpine ]]; then
+                $cmd update &>/dev/null
+                $cmd add $pkg &>/dev/null
+            else
+                $cmd update -y &>/dev/null
+                $cmd install -y $pkg &>/dev/null
+            fi
             [[ $? == 0 ]] && >$is_pkg_ok
         else
             >$is_pkg_ok
@@ -331,7 +350,12 @@ main() {
 
     timedatectl set-ntp true &>/dev/null
     [[ $? != 0 ]] && {
-        msg warn "${yellow}\e[4m提醒!!! 无法设置自动同步时间, 可能会影响使用 VMess 协议.${none}"
+        [[ $is_alpine ]] || msg warn "${yellow}\e[4m提醒!!! 无法设置自动同步时间, 可能会影响使用 VMess 协议.${none}"
+    }
+    # alpine 默认无 timedatectl, 尝试用 chronyd / ntpd 替代
+    [[ $is_alpine ]] && {
+        rc-service chronyd start &>/dev/null || rc-service ntpd start &>/dev/null || \
+            msg warn "${yellow}\e[4m提醒!!! 无法设置自动同步时间, 可能会影响使用 VMess 协议.${none}"
     }
 
     # install dependent pkg

--- a/src/core.sh
+++ b/src/core.sh
@@ -786,13 +786,13 @@ uninstall() {
     fi
     manage stop &>/dev/null
     manage disable &>/dev/null
-    rm -rf $is_core_dir $is_log_dir $is_sh_bin /lib/systemd/system/$is_core.service
+    rm -rf $is_core_dir $is_log_dir $is_sh_bin /lib/systemd/system/$is_core.service /etc/init.d/$is_core
     sed -i "/$is_core/d" /root/.bashrc
     # uninstall caddy; 2 is ask result
     if [[ $REPLY == '2' ]]; then
         manage stop caddy &>/dev/null
         manage disable caddy &>/dev/null
-        rm -rf $is_caddy_dir $is_caddy_bin /lib/systemd/system/caddy.service
+        rm -rf $is_caddy_dir $is_caddy_bin /lib/systemd/system/caddy.service /etc/init.d/caddy
     fi
     [[ $is_install_sh ]] && return # reinstall
     _green "\n卸载完成!"
@@ -835,7 +835,15 @@ manage() {
         is_do_name_msg=$is_core_name
         ;;
     esac
-    systemctl $is_do $is_do_name
+    if [[ $is_alpine ]]; then
+        case $is_do in
+        enable)  rc-update add $is_do_name default &>/dev/null ;;
+        disable) rc-update del $is_do_name default &>/dev/null ;;
+        *)       rc-service $is_do_name $is_do ;;
+        esac
+    else
+        systemctl $is_do $is_do_name
+    fi
     [[ $is_test_run && ! $is_new_install ]] && {
         sleep 2
         if [[ ! $(pgrep -f $is_run_bin) ]]; then
@@ -1465,7 +1473,11 @@ get() {
         bash <<<$is_install_sh
         ;;
     test-run)
-        systemctl list-units --full -all &>/dev/null
+        if [[ $is_alpine ]]; then
+            rc-status &>/dev/null
+        else
+            systemctl list-units --full -all &>/dev/null
+        fi
         [[ $? != 0 ]] && {
             _yellow "\n无法执行测试, 请检查 systemctl 状态.\n"
             return
@@ -1641,7 +1653,11 @@ url_qr() {
             if [[ $(type -P qrencode) ]]; then
                 qrencode -t ANSI "${is_url}"
             else
-                msg "请安装 qrencode: $(_green "$cmd update -y; $cmd install qrencode -y")"
+                if [[ $is_alpine ]]; then
+                    msg "请安装 qrencode: $(_green "$cmd add libqrencode-tools")"
+                else
+                    msg "请安装 qrencode: $(_green "$cmd update -y; $cmd install qrencode -y")"
+                fi
             fi
             msg
             msg "如果无法正常显示或识别, 请使用下面的链接来生成二维码:"

--- a/src/init.sh
+++ b/src/init.sh
@@ -58,8 +58,12 @@ _wget() {
     wget --no-check-certificate "$@"
 }
 
-# yum or apt-get
-cmd=$(type -P apt-get || type -P yum)
+# yum or apt-get or apk
+cmd=$(type -P apt-get || type -P yum || type -P apk)
+
+# alpine linux
+is_alpine=
+[[ $cmd =~ apk ]] && is_alpine=1
 
 # x64
 case $(arch) in
@@ -93,7 +97,8 @@ is_caddy_dir=/etc/caddy
 is_caddy_repo=caddyserver/caddy
 is_caddyfile=$is_caddy_dir/Caddyfile
 is_caddy_conf=$is_caddy_dir/$author
-is_caddy_service=$(systemctl list-units --full -all | grep caddy.service)
+is_caddy_service=$(systemctl list-units --full -all 2>/dev/null | grep caddy.service)
+[[ $is_alpine && -f /etc/init.d/caddy ]] && is_caddy_service=1
 is_http_port=80
 is_https_port=443
 
@@ -108,8 +113,8 @@ else
 fi
 if [[ -f $is_caddy_bin && -d $is_caddy_dir && $is_caddy_service ]]; then
     is_caddy=1
-    # fix caddy run; ver >= 2.8.2
-    [[ ! $(grep '\-\-adapter caddyfile' /lib/systemd/system/caddy.service) ]] && {
+    # fix caddy run; ver >= 2.8.2 (仅 systemd)
+    [[ ! $is_alpine ]] && [[ ! $(grep '\-\-adapter caddyfile' /lib/systemd/system/caddy.service) ]] && {
         load systemd.sh
         install_service caddy
         systemctl restart caddy &

--- a/src/systemd.sh
+++ b/src/systemd.sh
@@ -1,4 +1,52 @@
 install_service() {
+    # alpine: 使用 OpenRC
+    if [[ $is_alpine ]]; then
+        case $1 in
+        xray | v2ray)
+            cat >/etc/init.d/$is_core <<EOF
+#!/sbin/openrc-run
+name="$is_core_name"
+description="$is_core_name Service"
+command="$is_core_bin"
+command_args="run -config $is_config_json -confdir $is_conf_dir"
+command_background=true
+pidfile="/run/\${RC_SVCNAME}.pid"
+output_log="$is_log_dir/openrc.log"
+error_log="$is_log_dir/openrc.err"
+rc_ulimit="-n 1048576"
+
+depend() {
+    need net
+    use dns
+    after network
+}
+EOF
+            chmod +x /etc/init.d/$is_core
+            ;;
+        caddy)
+            cat >/etc/init.d/caddy <<EOF
+#!/sbin/openrc-run
+name="Caddy"
+description="Caddy"
+command="$is_caddy_bin"
+command_args="run --environ --config $is_caddyfile --adapter caddyfile"
+command_background=true
+pidfile="/run/\${RC_SVCNAME}.pid"
+rc_ulimit="-n 1048576"
+
+depend() {
+    need net
+    use dns
+    after network
+}
+EOF
+            chmod +x /etc/init.d/caddy
+            ;;
+        esac
+        rc-update add $1 default &>/dev/null
+        return
+    fi
+
     case $1 in
     xray | v2ray)
         is_doc_site=https://xtls.github.io/


### PR DESCRIPTION
更新对 alpine 发行版的支持，同时已经在 alpine 容器环境中测试通过。

具体使用说明如下，安装前请先安装必要的依赖:

```
apk add bash openrc wget
```

然后按常规方式执行安装即可:

```
bash <(wget -qO- https://github.com/233boy/xray/raw/main/install.sh)
```

说明:

- 服务通过 OpenRC 管理, 对应文件位于 `/etc/init.d/xray` 与 `/etc/init.d/caddy`
- `xray start | stop | restart | status` 等命令在 Alpine 上等效调用 `rc-service`
- Alpine 默认无 `timedatectl`, 脚本会尝试启动 `chronyd` 或 `ntpd` 来同步时间
- 如需二维码功能, 请安装: `apk add libqrencode-tools`

Link with: https://github.com/233boy/Xray/issues/112