### PR TITLE
fix: 修复手动更改 Reality 密钥后 VLESS 被错误改为 VMess-TCP

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -645,6 +645,7 @@ change() {
             get_pbk
             add $net
         else
+            local is_key_net=$net
             [[ $is_new_private_key && ! $is_new_public_key ]] && {
                 err "无法找到 Public key."
             }
@@ -657,6 +658,7 @@ change() {
             is_test_json=1
             # create server $is_protocol-$net | $is_core_bin -test &>/dev/null
             create server $is_protocol-$net
+            net=$is_key_net
             $is_core_bin -test <<<"$is_new_json" &>/dev/null
             if [[ $? != 0 ]]; then
                 err "Private key 无法通过测试."
@@ -664,6 +666,7 @@ change() {
             is_private_key=$is_new_public_key
             # create server $is_protocol-$net | $is_core_bin -test &>/dev/null
             create server $is_protocol-$net
+            net=$is_key_net
             $is_core_bin -test <<<"$is_new_json" &>/dev/null
             if [[ $? != 0 ]]; then
                 err "Public key 无法通过测试."


### PR DESCRIPTION
## 问题

在 TUI 中为 VLESS-Reality 配置手动更改 Private key 和 Public key 后，配置会被错误重建为 `VMess-TCP + Reality`；使用 `key auto` 自动生成密钥不受影响。

## 原因

手动更改密钥时，脚本会调用两次 `create server` 验证密钥。生成 Reality 配置的过程中，全局变量 `net` 会由 `reality` 变成底层传输类型 `tcp`。验证结束后继续执行 `add $net`，实际变成了 `add tcp`，因此协议被错误选择为 `VMess-TCP`，而 Reality 标记仍然保留。

## 修复

在密钥验证前保存原始的 `net` 值，并在每次验证后恢复，避免验证过程修改的全局状态影响最终配置重建。

## 验证

使用完整 TUI 流程进行前后对比：

- 修复前：更改密钥后生成 `VMess-TCP-端口.json`，内容为 `vmess + tcp + reality`
- 修复后：更改密钥后保持 `VLESS-REALITY-端口.json`，内容为 `vless + tcp + reality`
- 新的 Private key 和 Public key 均能正确写入