### PR TITLE
feat: add outbound IP preferences and remove Cloudflare Reality SNI domains

### DIFF
--- a/src/core.sh
+++ b/src/core.sh
@@ -1765,7 +1765,7 @@ is_main_menu() {
         show_help
         ;;
     9)
-        ask list is_do_other "启用BBR 查看日志 查看错误日志 测试运行 重装脚本 设置DNS"
+        ask list is_do_other "启用BBR 查看日志 查看错误日志 测试运行 重装脚本 设置DNS 设置出站IP优先级"
         case $REPLY in
         1)
             load bbr.sh
@@ -1786,6 +1786,10 @@ is_main_menu() {
         6)
             load dns.sh
             dns_set
+            ;;
+        7)
+            load ip.sh
+            ip_set
             ;;
         esac
         ;;

--- a/src/core.sh
+++ b/src/core.sh
@@ -108,8 +108,6 @@ servername_list=(
     www.amazon.com
     www.ebay.com
     www.paypal.com
-    www.cloudflare.com
-    dash.cloudflare.com
     aws.amazon.com
 )
 

--- a/src/ip.sh
+++ b/src/ip.sh
@@ -1,0 +1,17 @@
+is_ip_strategy_list=(
+    AsIs
+    UseIPv4v6
+    UseIPv6v4
+)
+ip_set() {
+    is_tmp_list=(自动 优先IPv4 优先IPv6)
+    ask list is_ip_use null "\n请选择出站 IP 优先级:\n"
+    is_ip_strategy=${is_ip_strategy_list[$REPLY - 1]}
+    if [[ $is_ip_strategy == 'AsIs' ]]; then
+        cat <<<$(jq '(.outbounds[] | select(.tag == "direct" and .protocol == "freedom")) |= (del(.settings.domainStrategy) | if .settings == {} then del(.settings) else . end)' $is_config_json) >$is_config_json
+    else
+        cat <<<$(jq --arg strategy "$is_ip_strategy" '(.outbounds[] | select(.tag == "direct" and .protocol == "freedom") | .settings.domainStrategy) = $strategy' $is_config_json) >$is_config_json
+    fi
+    manage restart &
+    msg "\n已更新出站 IP 优先级为: $(_green $is_ip_use)\n"
+}

--- a/xray.sh
+++ b/xray.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 args=$@
-is_sh_ver=v1.34
+is_sh_ver=v1.35
 
 . /etc/xray/sh/src/init.sh


### PR DESCRIPTION
## 修改内容

- 在 TUI 的“其他”菜单中增加“设置出站 IP 优先级”，支持自动、优先 IPv4 和优先 IPv6，分别使用 Freedom 默认策略、`UseIPv4v6` 和 `UseIPv6v4`
- 从 Reality 默认 serverName 随机候选列表中移除 `www.cloudflare.com` 和 `dash.cloudflare.com`
- 将脚本版本号更新至 v1.35

## 验证

- 已验证选择“优先 IPv4”后配置正确生效
- 已确认两个 Cloudflare 域名不再出现在 Reality 随机候选列表中

Closes #122
Closes #124